### PR TITLE
Refactor play and stop

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -230,7 +230,6 @@ class MusicBot:
             )
 
         if self.media_queue.empty():
-            logging.info(":sparkles: End of queue")
             self.current_media = None
             self.voice_client.stop()
             return
@@ -243,7 +242,6 @@ class MusicBot:
         audio_source = discord.FFmpegPCMAudio(audio_url)
 
         if self.voice_client.is_playing():
-            logging.info("Pausing with HACK")
             self._stop()
 
         logging.info("Playing audio source")
@@ -289,7 +287,7 @@ class MusicBot:
 
     async def notify_if_voice_client_is_missing(self, message):
         """
-        Returns True if a voice_client hasn't been created yet
+        Returns True and notifies the user if a voice_client hasn't been created yet
         """
         if not self.voice_client:
             await message.channel.send(":kissing_heart: Start playing something first")

--- a/bot.py
+++ b/bot.py
@@ -330,9 +330,11 @@ class MusicBot:
         """
         Stop currently playing song
         """
-        if not self.voice_client or self.media_queue.empty():
-                await message.channel.send(":sparkles: End of queue")
-                return
+        if (not self.voice_client or
+            self.media_queue.empty() and not self.voice_client.is_playing()
+        ):
+            await message.channel.send(":sparkles: End of queue")
+            return
 
         self._stop()
 
@@ -364,7 +366,9 @@ class MusicBot:
                 ":face_with_raised_eyebrow: Song currently playing"
             )
             return
-        if not self.voice_client or self.media_queue.empty():
+        if (not self.voice_client or
+            self.media_queue.empty() and not self.voice_client.is_paused()
+        ):
             await message.channel.send(":weary: Queue is empty!")
             return
 

--- a/bot.py
+++ b/bot.py
@@ -57,7 +57,7 @@ class MusicBot:
     # pylint: disable=no-self-use
     # pylint: disable=too-many-instance-attributes
 
-    COMMAND_PREFIX = "#"
+    COMMAND_PREFIX = "!"
     REACTION_EMOJI = "👍"
 
     NO_VOICE_CLIENT_ERROR_MSG = ":kissing_heart: Start playing something first"
@@ -530,7 +530,7 @@ class MusicBot:
 if __name__ == "__main__":
     print("Starting Discord bot")
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 

--- a/bot.py
+++ b/bot.py
@@ -210,6 +210,9 @@ class MusicBot:
         self.after_callback_blocked = True
         self.voice_client.stop()
 
+        if self.media_queue.empty():
+            self.current_media = None
+
     def next_in_queue(self):
         """
         Switch to next song in queue
@@ -396,7 +399,8 @@ class MusicBot:
         Displays media that has been queued
         """
         if self.current_media is None and self.media_queue.empty():
-            await message.channel.send(":clipboard: Nothing in queue :sparkles:")
+            await message.channel.send(":sparkles: Nothing in queue")
+            return
 
         reply = ""
         reply += ":notes: Now playing :notes:\n"

--- a/bot.py
+++ b/bot.py
@@ -56,7 +56,8 @@ class MusicBot:
     # pylint: disable=no-self-use
     # pylint: disable=too-many-instance-attributes
 
-    COMMAND_PREFIX = "!"
+    COMMAND_PREFIX = "#"
+    REACTION_EMOJI = "👍"
 
     def __init__(self, guild, loop, dispatcher_user):
         self.guild = guild
@@ -284,6 +285,14 @@ class MusicBot:
         if not voice_client:
             return
 
+        if not command_content:
+            if self.voice_client.is_paused():
+                await self.resume(message, command_content)
+                return
+            else:
+                await message.channel.send(":weary: Please enter something to search!")
+                return
+
         media = None
         try:
             if self.url_regex.match(command_content):
@@ -316,6 +325,7 @@ class MusicBot:
         """
         if self.voice_client:
             self.voice_client.stop()
+        await message.add_reaction(MusicBot.REACTION_EMOJI)
 
     async def pause(self, _message, _command_content):
         """
@@ -323,13 +333,15 @@ class MusicBot:
         """
         if self.voice_client:
             self.voice_client.pause()
+        await message.add_reaction(MusicBot.REACTION_EMOJI)
 
-    async def resume(self, _message, _command_content):
+    async def resume(self, message, _command_content):
         """
         Resume playing current song
         """
         if self.voice_client:
             self.voice_client.resume()
+        await message.add_reaction(MusicBot.REACTION_EMOJI)
 
     async def skip(self, message, _command_content):
         """
@@ -370,6 +382,7 @@ class MusicBot:
         """Disconnects the bot from the voice channel its connected to, if any."""
         if self.voice_client:
             await self.voice_client.disconnect()
+        await message.add_reaction(MusicBot.REACTION_EMOJI)
 
     async def hello(self, message, _command_content):
         """
@@ -466,7 +479,7 @@ class MusicBot:
 if __name__ == "__main__":
     print("Starting Discord bot")
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 

--- a/bot.py
+++ b/bot.py
@@ -45,6 +45,7 @@ class BotDispatcher(discord.Client):
         """
         if event_name == "on_message":
             message = args[0]
+            logging.error((event_name, args, kwargs))
             await message.channel.send(":robot: Something came up!")
 
 
@@ -92,7 +93,9 @@ class MusicBot:
         self.register_command(
             "disconnect", handler=self.disconnect, guarded_by=self.voice_lock
         )
-        self.register_command("queue", handler=self.show_queue)
+        self.register_command(
+            "queue", handler=self.show_queue, guarded_by=self.voice_lock
+        )
 
         self.register_command("hello", handler=self.hello)
         self.register_command("countdown", handler=self.countdown)

--- a/bot.py
+++ b/bot.py
@@ -60,7 +60,6 @@ class MusicBot:
     COMMAND_PREFIX = "!"
     REACTION_EMOJI = "👍"
 
-    NO_VOICE_CLIENT_ERROR_MSG = ":kissing_heart: Start playing something first"
     END_OF_QUEUE_MSG = ":sparkles: End of queue"
 
     def __init__(self, guild, loop, dispatcher_user):
@@ -288,6 +287,15 @@ class MusicBot:
 
         return self.voice_client
 
+    async def notify_if_voice_client_is_missing(self, message):
+        """
+        Returns True if a voice_client hasn't been created yet
+        """
+        if not self.voice_client:
+            await message.channel.send(":kissing_heart: Start playing something first")
+            return True
+        return False
+
     async def play(self, message, command_content):
         """
         Play URL or first search term from command_content in the author's voice channel
@@ -341,8 +349,7 @@ class MusicBot:
         """
         Stop currently playing song
         """
-        if not self.voice_client:
-            await message.channel.send(MusicBot.NO_VOICE_CLIENT_ERROR_MSG)
+        if await self.notify_if_voice_client_is_missing(message):
             return
         if self.media_queue.empty() and not self.voice_client.is_playing():
             await message.channel.send(MusicBot.END_OF_QUEUE_MSG)
@@ -355,8 +362,7 @@ class MusicBot:
         """
         Pause currently playing song
         """
-        if not self.voice_client:
-            await message.channel.send(MusicBot.NO_VOICE_CLIENT_ERROR_MSG)
+        if await self.notify_if_voice_client_is_missing(message):
             return
         if not self.voice_client.is_playing():
             await message.channel.send(
@@ -371,8 +377,7 @@ class MusicBot:
         """
         Resume playing current song
         """
-        if not self.voice_client:
-            await message.channel.send(MusicBot.NO_VOICE_CLIENT_ERROR_MSG)
+        if await self.notify_if_voice_client_is_missing(message):
             return
         if self.media_queue.empty() and not self.voice_client.is_paused():
             await message.channel.send(MusicBot.END_OF_QUEUE_MSG)
@@ -393,8 +398,7 @@ class MusicBot:
         """
         Skip to next song in queue
         """
-        if not self.voice_client:
-            await message.channel.send(MusicBot.NO_VOICE_CLIENT_ERROR_MSG)
+        if await self.notify_if_voice_client_is_missing(message):
             return
 
         if self.media_queue.empty():


### PR DESCRIPTION
1. This PR addresses issues #10 and #25.

2. It fixes a bug:

    - `!pause` sometimes skips the song if it's the last one in the queue

3. It changes `self.voice_lock` to `self.command_lock` and applies it to the `!queue` command. This fixed a bug that arose after the other changes, where `!queue` would start to cause other commands to throw errors.
4. It adds error logging to `on_error()`