### PR TITLE
Automatically disconnect from voice channel

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,8 +65,8 @@ class MusicBot:
 
     COMMAND_PREFIX = "!"
     REACTION_EMOJI = "👍"
-    DISCONNECT_STOP_TIMER = 60
-    DISCONNECT_PAUSE_TIMER = 600
+    DISCONNECT_STOP_TIMER = 3
+    DISCONNECT_PAUSE_TIMER = 5
 
     END_OF_QUEUE_MSG = ":sparkles: End of queue"
 
@@ -310,22 +310,24 @@ class MusicBot:
         Checks every few seconds whether the voice_client is playing something in a
         voice channel. If it's not then the bot will be automatically disconnected.
         """
-        if self.voice_client and not self.voice_client.is_playing():
-            time_since_last_command = time.time() - self.last_command_time
+        if not self.voice_client or self.voice_client.is_playing():
+            return
 
-            if (
-                self.voice_client.is_paused()
-                and time_since_last_command < MusicBot.DISCONNECT_PAUSE_TIMER
-            ):
-                return
+        time_since_last_command = time.time() - self.last_command_time
 
-            if time_since_last_command < MusicBot.DISCONNECT_STOP_TIMER:
-                return
+        if (
+            self.voice_client.is_paused()
+            and time_since_last_command < MusicBot.DISCONNECT_PAUSE_TIMER
+        ):
+            return
 
-            async with self.command_lock:
-                self._stop()
-                await self.voice_client.disconnect()
-                self.voice_client = None
+        if time_since_last_command < MusicBot.DISCONNECT_STOP_TIMER:
+            return
+
+        async with self.command_lock:
+            self._stop()
+            await self.voice_client.disconnect()
+            self.voice_client = None
 
     async def notify_if_voice_client_is_missing(self, message):
         """

--- a/bot.py
+++ b/bot.py
@@ -327,8 +327,6 @@ class MusicBot:
                 await self.voice_client.disconnect()
                 self.voice_client = None
 
-        await asyncio.sleep(5)
-
     async def notify_if_voice_client_is_missing(self, message):
         """
         Returns True and notifies the user if a voice_client hasn't been created yet

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,7 @@ import logging
 import asyncio
 import queue
 import traceback
-from time import time
+import time
 
 import discord
 import jokeapi
@@ -310,15 +310,13 @@ class MusicBot:
             "Will attempt to disconnect in %s seconds",
             MusicBot.DISCONNECT_TIMER_SECONDS,
         )
-        self.last_played_time = time()
+        self.last_played_time = time.time()
         await asyncio.sleep(MusicBot.DISCONNECT_TIMER_SECONDS)
 
         if self.voice_client.is_playing():
             return
 
-        buffer = 5
-        time_since_last_played = time() - self.last_played_time
-        if time_since_last_played + buffer < self.DISCONNECT_TIMER_SECONDS:
+        if self.last_played_time < self.DISCONNECT_TIMER_SECONDS:
             return
 
         self._stop()
@@ -407,7 +405,7 @@ class MusicBot:
 
         self._stop()
         logging.info("Stopped media for user %s", message.author)
-        await self.attempt_disconnect()
+        self.loop.create_task(self.attempt_disconnect())
         await message.add_reaction(MusicBot.REACTION_EMOJI)
 
     async def pause(self, message, _command_content):
@@ -427,7 +425,7 @@ class MusicBot:
 
         self.voice_client.pause()
         logging.info("Paused media for user %s", message.author)
-        await self.attempt_disconnect()
+        self.loop.create_task(self.attempt_disconnect())
         await message.add_reaction(MusicBot.REACTION_EMOJI)
 
     async def resume(self, message, _command_content):

--- a/bot.py
+++ b/bot.py
@@ -61,6 +61,7 @@ class MusicBot:
 
     # pylint: disable=no-self-use
     # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-public-methods
 
     COMMAND_PREFIX = "!"
     REACTION_EMOJI = "👍"
@@ -306,7 +307,8 @@ class MusicBot:
         checking whether anything is currently playing.
         """
         logging.info(
-            f"Will attempt to disconnect in {MusicBot.DISCONNECT_TIMER_SECONDS} seconds"
+            "Will attempt to disconnect in %s seconds",
+            MusicBot.DISCONNECT_TIMER_SECONDS,
         )
         self.last_played_time = time()
         await asyncio.sleep(MusicBot.DISCONNECT_TIMER_SECONDS)
@@ -316,7 +318,7 @@ class MusicBot:
 
         buffer = 5
         time_since_last_played = time() - self.last_played_time
-        if  time_since_last_played + buffer < self.DISCONNECT_TIMER_SECONDS:
+        if time_since_last_played + buffer < self.DISCONNECT_TIMER_SECONDS:
             return
 
         self._stop()

--- a/bot.py
+++ b/bot.py
@@ -62,7 +62,7 @@ class MusicBot:
     # pylint: disable=no-self-use
     # pylint: disable=too-many-instance-attributes
 
-    COMMAND_PREFIX = "-"
+    COMMAND_PREFIX = "!"
     REACTION_EMOJI = "👍"
     DISCONNECT_TIMER_SECONDS = 600
 
@@ -301,9 +301,9 @@ class MusicBot:
 
     async def attempt_disconnect(self):
         """
-        Should be called whenever a song finishes playing. Attempts to disconnect the
-        voice client after a set amount of time by checking whether anything is
-        currently playing.
+        Should be called whenever a song finishes playing, or when media is paused or
+        stopped. Attempts to disconnect the voice client after a set amount of time by
+        checking whether anything is currently playing.
         """
         logging.info(
             f"Will attempt to disconnect in {MusicBot.DISCONNECT_TIMER_SECONDS} seconds"

--- a/bot.py
+++ b/bot.py
@@ -311,18 +311,18 @@ class MusicBot:
         voice channel. If it's not then the bot will be automatically disconnected.
         """
         if self.voice_client and not self.voice_client.is_playing():
+            time_since_last_command = time.time() - self.last_command_time
+
+            if (
+                self.voice_client.is_paused()
+                and time_since_last_command < MusicBot.DISCONNECT_PAUSE_TIMER
+            ):
+                return
+
+            if time_since_last_command < MusicBot.DISCONNECT_STOP_TIMER:
+                return
+
             async with self.command_lock:
-                time_since_last_command = time.time() - self.last_command_time
-
-                if (
-                    self.voice_client.is_paused()
-                    and time_since_last_command < MusicBot.DISCONNECT_PAUSE_TIMER
-                ):
-                    return
-
-                if time_since_last_command < MusicBot.DISCONNECT_STOP_TIMER:
-                    return
-
                 self._stop()
                 await self.voice_client.disconnect()
                 self.voice_client = None


### PR DESCRIPTION
Makes it so that the bot will automatically disconnect from the voice channel after a set amount of time of voice inactivity.

Also fixes a bug where that would happen when online media was not successfully found. Bot now correctly reports the error and ignores it.

Closes #8