### PR TITLE
Bugfix: songs being dropped when adding them to the queue

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Lirary among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.b

--- a/bot.py
+++ b/bot.py
@@ -429,7 +429,7 @@ class MusicBot:
 
     def pafy_search(self, youtube_link_or_id):
         """Search for youtube link with pafy"""
-        media = pafy.new(youtube_link_or_id, gdata=False)
+        media = pafy.new(youtube_link_or_id)
         if media.dislikes == "N/A":
             logging.info("Ignoring dislike count in new media")
 

--- a/bot.py
+++ b/bot.py
@@ -14,8 +14,8 @@ import time
 
 import discord
 import jokeapi
-import pafy_fixed.pafy_fixed as pafy
 import youtubesearchpython
+import pafy_fixed.pafy_fixed as pafy
 
 
 class BotDispatcher(discord.Client):
@@ -429,7 +429,11 @@ class MusicBot:
 
     def pafy_search(self, youtube_link_or_id):
         """Search for youtube link with pafy"""
-        return pafy.new(youtube_link_or_id, gdata=False)
+        media = pafy.new(youtube_link_or_id, gdata=False)
+        if media.dislikes == "N/A":
+            logging.info("Ignoring dislike count in new media")
+
+        return media
 
     def youtube_search(self, search_str):
         """Search for search_str on youtube"""

--- a/bot.py
+++ b/bot.py
@@ -430,7 +430,7 @@ class MusicBot:
     def pafy_search(self, youtube_link_or_id):
         """Search for youtube link with pafy"""
         media = pafy.new(youtube_link_or_id)
-        if media.dislikes == "N/A":
+        if media.dislikes == 0:
             logging.info("Ignoring dislike count in new media")
 
         return media

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,7 @@ import time
 
 import discord
 import jokeapi
-import pafy
+import pafy_fixed.pafy_fixed as pafy
 import youtubesearchpython
 
 
@@ -429,7 +429,7 @@ class MusicBot:
 
     def pafy_search(self, youtube_link_or_id):
         """Search for youtube link with pafy"""
-        return pafy.new(youtube_link_or_id)
+        return pafy.new(youtube_link_or_id, gdata=False)
 
     def youtube_search(self, search_str):
         """Search for search_str on youtube"""

--- a/pafy_fixed/backend_youtube_dl_fixed.py
+++ b/pafy_fixed/backend_youtube_dl_fixed.py
@@ -47,8 +47,8 @@ class YtdlPafyFixed(YtdlPafy):
         self._rating = self._ydl_info['average_rating']
         self._length = self._ydl_info['duration']
         self._viewcount = self._ydl_info['view_count']
-        self._likes = self._ydl_info['like_count']
-        # added a default value for dislike_count
+        # added a default value for like_count and dislike_count
+        self._likes = self._ydl_info.get('like_count', 0)
         self._dislikes = self._ydl_info.get('dislike_count', 0)
         self._username = self._ydl_info['uploader_id']
         self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''

--- a/pafy_fixed/backend_youtube_dl_fixed.py
+++ b/pafy_fixed/backend_youtube_dl_fixed.py
@@ -1,3 +1,6 @@
+# pylint: skip-file
+# fmt: off
+
 import sys
 import time
 import logging

--- a/pafy_fixed/backend_youtube_dl_fixed.py
+++ b/pafy_fixed/backend_youtube_dl_fixed.py
@@ -49,7 +49,7 @@ class YtdlPafyFixed(YtdlPafy):
         self._viewcount = self._ydl_info['view_count']
         self._likes = self._ydl_info['like_count']
         # added a default value for dislike_count
-        self._dislikes = self._ydl_info.get('dislike_count', 'N/A')
+        self._dislikes = self._ydl_info.get('dislike_count', 0)
         self._username = self._ydl_info['uploader_id']
         self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''
         self._bestthumb = self._ydl_info['thumbnails'][0]['url']

--- a/pafy_fixed/backend_youtube_dl_fixed.py
+++ b/pafy_fixed/backend_youtube_dl_fixed.py
@@ -1,0 +1,57 @@
+import sys
+import time
+import logging
+import os
+import subprocess
+
+if sys.version_info[:2] >= (3, 0):
+    # pylint: disable=E0611,F0401,I0011
+    uni = str
+else:
+    uni = unicode
+
+import youtube_dl
+
+import pafy.g as g
+from pafy.backend_shared import BasePafy, BaseStream, remux, get_status_string, get_size_done
+
+from pafy.backend_youtube_dl import YtdlPafy
+
+class YtdlPafyFixed(YtdlPafy):
+    """
+    Modified version of pafy.backend_youtube_dl.YtdlPafy
+    """
+    def __init__(self, *args, **kwargs):
+        super(YtdlPafyFixed, self).__init__(*args, **kwargs)
+
+    def _fetch_basic(self):
+        """ Fetch basic data and streams. """
+        if self._have_basic:
+            return
+
+        with youtube_dl.YoutubeDL(self._ydl_opts) as ydl:
+            try:
+                self._ydl_info = ydl.extract_info(self.videoid, download=False)
+            # Turn into an IOError since that is what pafy previously raised
+            except youtube_dl.utils.DownloadError as e:
+                raise IOError(str(e).replace('YouTube said', 'Youtube says'))
+
+        if self.callback:
+            self.callback("Fetched video info")
+
+        self._title = self._ydl_info['title']
+        self._author = self._ydl_info['uploader']
+        self._rating = self._ydl_info['average_rating']
+        self._length = self._ydl_info['duration']
+        self._viewcount = self._ydl_info['view_count']
+        self._likes = self._ydl_info['like_count']
+        # added a default value for dislike_count
+        self._dislikes = self._ydl_info.get('dislike_count', 'N/A')
+        self._username = self._ydl_info['uploader_id']
+        self._category = self._ydl_info['categories'][0] if self._ydl_info['categories'] else ''
+        self._bestthumb = self._ydl_info['thumbnails'][0]['url']
+        self._bigthumb = g.urls['bigthumb'] % self.videoid
+        self._bigthumbhd = g.urls['bigthumbhd'] % self.videoid
+        self.expiry = time.time() + g.lifespan
+
+        self._have_basic = True

--- a/pafy_fixed/pafy_fixed.py
+++ b/pafy_fixed/pafy_fixed.py
@@ -1,0 +1,18 @@
+from pafy import *
+
+Pafy = None
+
+def new(url, basic=True, gdata=False, size=False,
+        callback=None, ydl_opts=None):
+    """
+    Modified version of pafy.new()
+    """
+    global Pafy
+    if Pafy is None:
+        if backend == "internal":
+           from pafy.backend_internal import InternPafy as Pafy
+        else:
+            # changed this line
+           from pafy_fixed.backend_youtube_dl_fixed import YtdlPafyFixed as Pafy
+
+    return Pafy(url, basic, gdata, size, callback, ydl_opts=ydl_opts)

--- a/pafy_fixed/pafy_fixed.py
+++ b/pafy_fixed/pafy_fixed.py
@@ -1,4 +1,7 @@
-from pafy import *
+# pylint: skip-file
+# fmt: off
+
+from pafy.pafy import *
 
 Pafy = None
 


### PR DESCRIPTION
This PR fixes a bug where songs are often dropped when trying to add them to the queue. It does this by fixing the "dislike_count" error that popped up after youtube removed dislikes on their videos. 

A side effect is that it seems to speed up the time it takes to add multiple songs to the queue, so it might help with https://github.com/michael-je/the-lone-dancer/pull/49#discussion_r753667932.

I've simply customized `pafy.new()` so that the `_dislikes` variable of its youtube backend has a default value if none is found.

~~I'll probably add a PR to the pafy repository as well~~ Someone beat me to it: https://github.com/mps-youtube/pafy/pull/305. In the meantime though, this dirty fix should do the trick.