### PR TITLE
Add `-playnext`

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -500,7 +500,7 @@ class MusicBot:
 
         return media
 
-    async def play(self, message, command_content, deque_append_left=False):
+    async def play(self, message, command_content, playnext=False):
         """
         Play URL or first search term from command_content in the author's voice channel
         """
@@ -531,7 +531,7 @@ class MusicBot:
 
         logging.info("Media found:\n%s", media)
 
-        if deque_append_left:
+        if playnext:
             self.media_deque.appendleft((media, message))
         else:
             self.media_deque.append((media, message))

--- a/bot.py
+++ b/bot.py
@@ -482,9 +482,10 @@ class MusicBot:
         """
         media = None
         try:
-            if self.url_regex.match(command_content):
+            url = self.url_regex.search(command_content)
+            if url:
                 logging.info("Fetching video metadata with pafy")
-                media = self.pafy_search(command_content)
+                media = self.pafy_search(url.group())
             else:
                 logging.info("Fetching search results with pafy")
                 search_result = self.youtube_search(command_content)


### PR DESCRIPTION
Adds the `-playnext` command which allows for adding songs to the front of the queue rather than the back.
In order to achieve this `queue.Queue` had to be swapped out for `collections.deque`, but all the logic is functionally the same.

Also changed url parsing so that urls can now be anywhere in the user message.

closes #52 