### PR TITLE
Fix unittests not catching warnings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -391,7 +391,7 @@ class MusicBot:
             self.loop.create_task(
                 message.channel.send("Sorry, I can't play livestreams :sob:")
             )
-            self.next_in_queue()
+            await self.next_in_queue()
             return
 
         audio_url = media.getbestaudio().url

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -82,6 +82,22 @@ def create_mock_message(
     return message
 
 
+def async_assert_no_warnings_wrapper(func):
+    """
+    Add this wrapper to tests to make sure that warnings are also cought as errors
+    """
+
+    def inner(self):
+        with warnings.catch_warnings(record=True) as cought_warnings:
+            self.dispatcher_.loop.run_until_complete(func(self))
+
+            if len(cought_warnings) != 0:
+                MusicBotTest.total_warnings += cought_warnings
+                raise Warning
+
+    return inner
+
+
 class MusicBotTest(unittest.IsolatedAsyncioTestCase):
     """MusicBot test suite"""
 
@@ -119,21 +135,6 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
         warnings_report += "\n\n==========================="
 
         print(warnings_report)
-
-    def async_assert_no_warnings_wrapper(func): # pylint: disable=no-self-argument
-        """
-        Add this wrapper to tests to make sure that warnings are also cought as errors
-        """
-
-        def inner(self):
-            with warnings.catch_warnings(record=True) as cought_warnings:
-                self.dispatcher_.loop.run_until_complete(func(self))
-
-                if len(cought_warnings) != 0:
-                    MusicBotTest.total_warnings += cought_warnings
-                    raise Warning
-
-        return inner
 
     @async_assert_no_warnings_wrapper
     async def test_ignores_own_message(self):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-module-docstring
 
 from unittest import mock
+import warnings
 import asyncio
 import unittest
 import bot
@@ -103,6 +104,38 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
             return_value=self.mock_audio_source_
         )
 
+    @classmethod
+    def setUpClass(cls):
+        cls.total_warnings = []
+
+    @classmethod
+    def tearDownClass(cls):
+        if len(cls.total_warnings) == 0:
+            return
+
+        warnings_report = "\n\n======== WARNINGS ========="
+        for warning in cls.total_warnings:
+            warnings_report += "\n\n" + str(warning.message)
+        warnings_report += "\n\n==========================="
+
+        print(warnings_report)
+
+    def async_assert_no_warnings_wrapper(func): # pylint: disable=no-self-argument
+        """
+        Add this wrapper to tests to make sure that warnings are also cought as errors
+        """
+
+        def inner(self):
+            with warnings.catch_warnings(record=True) as cought_warnings:
+                self.dispatcher_.loop.run_until_complete(func(self))
+
+                if len(cought_warnings) != 0:
+                    MusicBotTest.total_warnings += cought_warnings
+                    raise Warning
+
+        return inner
+
+    @async_assert_no_warnings_wrapper
     async def test_ignores_own_message(self):
         message = create_mock_message(
             contents="-Some bot message", author=self.dispatcher_.user
@@ -113,6 +146,7 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
         # Bot didn't respond with anything.
         message.channel.send.assert_not_awaited()
 
+    @async_assert_no_warnings_wrapper
     async def test_ignores_message_without_command_prefix(self):
         ignore_message = create_mock_message(contents="Some non-command message")
 
@@ -121,6 +155,7 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
         # Bot didn't respond with anything.
         ignore_message.channel.send.assert_not_awaited()
 
+    @async_assert_no_warnings_wrapper
     async def test_hello_command_sends_message(self):
         hello_message = create_mock_message(contents="-hello")
 
@@ -128,6 +163,7 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
 
         hello_message.channel.send.assert_awaited_with(":wave: Hello! default_user")
 
+    @async_assert_no_warnings_wrapper
     async def test_play_fails_when_user_not_in_voice_channel(self):
         play_message = create_mock_message(
             contents="-play song", author=create_mock_author()
@@ -140,6 +176,7 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
             "the :robot:"
         )
 
+    @async_assert_no_warnings_wrapper
     async def test_play_connects_deafaned(self):
         play_message = create_mock_message(
             contents="-play song",
@@ -170,6 +207,7 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
             ":notes: Now Playing :notes:\n```\nsong\n```"
         )
 
+    @async_assert_no_warnings_wrapper
     async def test_second_play_command_queues_media(self):
         author = create_mock_author(
             voice_state=create_mock_voice_state(channel=create_mock_voice_channel())
@@ -202,6 +240,7 @@ class MusicBotTest(unittest.IsolatedAsyncioTestCase):
             ":notes: Now Playing :notes:\n```\nsong2\n```"
         )
 
+    @async_assert_no_warnings_wrapper
     async def test_play_livestream_informs_user_unable_to_play(self):
         mock_author = create_mock_author(
             voice_state=create_mock_voice_state(channel=create_mock_voice_channel())


### PR DESCRIPTION
Since the discord module raises warnings instead of errors under most circumstances, some bugs were not being cought by our automatic tests:

```
Run python -m unittest tests/*.py
...../home/runner/work/the-lone-dancer/the-lone-dancer/bot.py:394: RuntimeWarning: coroutine 'MusicBot.next_in_queue' was never awaited
Coroutine created at (most recent call last)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 603, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.8/asyncio/base_events.py", line 570, in run_forever
    self._run_once()
  File "/usr/lib/python3.8/asyncio/base_events.py", line 1851, in _run_once
    handle._run()
  File "/usr/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/lib/python3.8/unittest/async_case.py", line 102, in _asyncioLoopRunner
    ret = await awaitable
  File "/home/runner/work/the-lone-dancer/the-lone-dancer/tests/test_bot.py", line 217, in test_play_livestream_informs_user_unable_to_play
    await self.music_bot_.handle_message(play_message)
  File "/home/runner/work/the-lone-dancer/the-lone-dancer/bot.py", line 346, in handle_message
    await handler(message, command_content)
  File "/home/runner/work/the-lone-dancer/the-lone-dancer/bot.py", line 277, in guarded_handler
    return await handler(*args)
  File "/home/runner/work/the-lone-dancer/the-lone-dancer/bot.py", line 617, in play
    await self.next_in_queue()
  File "/home/runner/work/the-lone-dancer/the-lone-dancer/bot.py", line 394, in next_in_queue
    self.next_in_queue()
  self.next_in_queue()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
..
----------------------------------------------------------------------
Ran 7 tests in 0.281s

OK
```

This bug in particular was probably never cought because we never tried to actually play a livestream. 

However, bugs of this nature are both harmful and very easy to make by accident and should definitely not be slipping through our tests. Therefor, this PR adds a wrapper function to the MusicBotTest class which can be used to catch these warnings.

It also fixes the bug that was causing this particular warning.